### PR TITLE
Fix workflow permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,7 @@
 name: Ruff
 on: [ push, pull_request ]
+permissions:
+  contents: read
 jobs:
   ruff:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/jfleach/gemini/security/code-scanning/1](https://github.com/jfleach/gemini/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow uses `actions/checkout` and `astral-sh/ruff-action`, it likely only needs read access to the repository contents. We will set `contents: read` as the minimal required permission. This change ensures the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
